### PR TITLE
Parserを修正

### DIFF
--- a/ChatTextView/Classes/Parser.swift
+++ b/ChatTextView/Classes/Parser.swift
@@ -73,7 +73,7 @@ enum Parser {
             if let mentionId = attr[mentionIdAttrKey] as? String, !mentionId.isEmpty {
                 let m = TextTypeMention(
                     displayString: character,
-                    metadata: usedMentions[i].metadata
+                    metadata: ""
                 )
                 result.append(TextType.mention(m))
                 continue


### PR DESCRIPTION
https://github.com/sikmi/ChatTextView-ios/commit/adb37b92d381301883508e0c0a55120f97e3ce29#diff-e1040c8d57ae0b3417c7dde52eba5d69 のdiffを見るともともと同じ文字列を入れていただけなので正しく整形していた訳ではなさそう。変更を適用したところFirestoreにも正常に保存された。